### PR TITLE
Disable (semi-permanently) mult-threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 # *.[oa]
 # *~
 
+
+*.t2d
+*.toc
+*.fns
+*.fn
 *.log
 *.aux
 *.dvi

--- a/doc/internals/concurency.org
+++ b/doc/internals/concurency.org
@@ -1,0 +1,97 @@
+
+
+
+* Concurrency
+
+  The current version of Garnett suffers from a fatal flaw with
+  respect to concurency: the CLX librabry is not thread safe and there
+  is no mechanism to broker interaction between the message pump and
+  the interactive shell.
+
+** Current state
+   Concurrency is supposed to be controled by the interaction of two
+   settings:
+   
+   1) The cmu feature, i.e. #+cmu and #-cmu
+
+   2) launch-process-p
+
+   If cmu is enabled, then CMU uses it's own multiprogramming mode to
+   interact with CLX. This is (apperently) a most single threaded
+   approach, but yeilds for certain io operations. The main entry
+   point for the message pump is:
+
+   #+BEGIN_SRC lisp :tangle start-swank-server.lisp
+     (ext:enable-clx-event-handling opal::*default-x-display*
+				    #'inter::default-event-handler)
+   #+END_SRC
+
+   For non-CMU lisps that support multi-processing, i.e. alegro and
+   lucid (we're talking early 90s here), the following is the
+   entrypoint: 
+
+   #+BEGIN_SRC lisp :tangle start-swank-server.lisp
+     (when user::launch-process-p
+       (opal:launch-main-event-loop-process))
+   #+END_SRC
+
+   That sets the special *main-event-loop-process* to the message pump
+   thread. The main event loop can be kill (semi-politely) using
+   kill-main-event-loop-process 
+
+   If launch-process-p is nil, then *main-event-loop-process* will
+   never be set. This changes the behavior of main-event-loop. If
+   *main-event-loop-process* is non-null, garnet has been started in
+   multi-process mode, and the call to main-event-loop is a no op,
+   (because the event loop is already running) However, if
+   *main-event-loop-process* is nil then a call to main-event-loop
+   will begin the message pump, blocking until the last window has
+   been killed.
+
+
+** Correct Approach
+
+   For Garnett to be multi-threaded there are three problems that need
+   to be overcome:
+
+   1) Access to CLX needs to be locked so that only one thread at a
+      time can use it. Since CLX itself is the source of messages,
+      this means that any time a thread calls into the library,
+      another thread isn't listening for events.
+
+   2) The underlying Garnet infrastructure needs to be made
+      multi-threaded. The class system is the most critical of these,
+      since creating new classes updates a database of classes that's
+      globally available.
+
+   3) Must of Common Lisp itself is not thread safe, there should be
+      clear conventions, and ideally programming constructs that
+      fascilitate syncranization.
+
+** Ideas
+   These are not trivial changes. Below are some ideas
+
+   - Review Haiku (the free version of the BeOS) operating system,
+     which is highly concurrent.
+
+   - In critical operations, espectially with CLX move to a message
+     passing form of interaction.
+
+   - Settle for 'partial' multithread, workers, application framework
+     in one thread, CLX interaction in another.
+
+   - Opt for a multi-process framework, where interaction occures
+     between seperate lisp images (and provide communications to make
+     such interactions convenient to use and well integrated with Garnett.)
+
+   - Maybe threading is foolish to address within the contex of
+     Garnett, i.e. performance is perfectly adequane with a single
+     thread and multi-processing is better handled within the
+     applicaiton domain.
+
+
+* Conclusion
+
+  threading is multi-threading is turned off by default, and can only
+  be considered a broken, legacy (mis)feature until the substatial
+  issues are resolved.

--- a/multi-garnet/multi-garnet.lisp
+++ b/multi-garnet/multi-garnet.lisp
@@ -1431,5 +1431,8 @@
 	))
     ))
 
+
 (eval-when (:load-toplevel :execute)
-  (enable-multi-garnet))
+  ;; This needs to be called after Garnet loads, do to concurency issues.
+  ;;(enable-multi-garnet))
+  )

--- a/src/gem/gem-lab/gem-lab.lisp
+++ b/src/gem/gem-lab/gem-lab.lisp
@@ -1,3 +1,8 @@
+
+
+(ql:quickload :clx)
+(ql:quickload :bordeaux-threads)
+
 (defpackage :gem-lab
   (:use common-lisp
 	;; gem
@@ -308,41 +313,51 @@
     (unless (eq selected-item :none)
       selected-item)))
 
+(defparameter *display* nil)
+(defparameter *screen* nil)
+(defparameter *a-menu* nil)
+
 (defun just-say-lisp (&optional host font-name)
-  (let* ((display
-	  (if host
-	      (open-display host)
-	      (xlib::open-default-display)))
-	 (screen
-	  (first (display-roots display)))
-	 (fg-color (screen-black-pixel screen))
-	 (bg-color (screen-white-pixel screen))
+  (setf *display*
+	(if host
+	    (open-display host)
+	    (xlib::open-default-display)))
+  (setf *screen* (first (display-roots *display*)))
+  (let* ((fg-color (screen-black-pixel *screen*))
+	 (bg-color (screen-white-pixel *screen*))
 	 ;; font-name used to have a default of "fg-16" But,
 	 ;; apperently, this is no longer commonly included in a basic
-	 ;; X11 installation. At least it was missing from Ubuntu 19.10.
-	 (nice-font (if font-name
-			(open-font display font-name)
-			(car (xlib:list-fonts
-			 (xlib::open-default-display)
-			 "*-adobe-times-medium-*34-240-*-170*-iso8859-1"))))
+	 ;; X11 installation. At least it was missing from Ubuntu
+	 ;; 19.10.
+	 (nice-font
+	  (if font-name
+	      (open-font *display* font-name)
+	      (car (xlib:list-fonts
+		    (xlib::open-default-display)
+		    "*-adobe-times-medium-*34-240-*-170*-iso8859-1")))))
 	 ;; Create a menu as a child of the root window.
-	 (a-menu
-	  (create-menu (screen-root screen)
-		       fg-color bg-color nice-font)))
-    (setf (menu-title a-menu) "please pick your favorite language:")
-    (menu-set-item-list a-menu "fortran" "apl" "forth" "lisp")
+    (setf *a-menu*
+	  (create-menu (screen-root *screen*)
+		       fg-color bg-color nice-font))
+    (setf (menu-title *a-menu*) "please pick your favorite language:")
+    (menu-set-item-list *a-menu* "fortran" "apl" "forth" "lisp")))
+
+(defun do-menu ()
     ;; Bedevil the user until he picks a nice programming language
-    ;; (unwind-protect
-    ;; 	 (loop
-    ;; 	    ;; Determine the current root window position of the pointer
-    ;; 	    (multiple-value-bind (x y)
-    ;; 		(query-pointer (screen-root screen))
-    	      (let ((choice (menu-choose a-menu 50 50)))
-    		;; (when (string-equal "lisp" choice)
-    		;;   (return))
-		)
-    ;;   (close-display display))
-    ))
+    (unwind-protect
+  ;;  	 (loop
+    	    ;; Determine the current root window position of the
+    	    ;; pointer
+	    (sleep 1)
+    	    ;; (multiple-value-bind (x y)
+    	    ;; 	(query-pointer (screen-root *screen*))
+    	    ;;   (let ((choice
+	    (menu-choose *a-menu* 50 50)))
+      ;; 	    ))
+      ;; 		(when (string-equal "lisp" choice)
+      ;; 		  (return)))))
+      ;; (close-display *display*)
+;;))
 
 (defun menu-unhighlight-item (menu position)
   ;; Draw a box in the menu background color

--- a/src/gem/gem-lab/gem-lab.lisp
+++ b/src/gem/gem-lab/gem-lab.lisp
@@ -1,7 +1,29 @@
-(in-package :gem)
+(defpackage :gem-lab
+  (:use common-lisp
+	;; gem
+	xlib)
+  (:shadowing-import-from :xlib
+			  draw-lines
+			  text-extents
+			  draw-points
+			  create-image
+			  draw-line
+			  draw-arc
+			  create-window
+			  create-cursor
+			  event-handler
+			  clear-area
+			  text-width
+			  translate-coordinates
+			  create-pixmap
+			  draw-rectangle))
+
+(in-package :gem-lab)
 
 (defun run-all-garnet-windows ()
-  (x-all-garnet-windows *default-x-root*))
+  (x-all-garnet-windows)
+  ;;gem::*default-x-root*
+  )
 
 
 ;;; create window
@@ -9,7 +31,7 @@
 ;;; apply bitmap
 
 (defun the-colormap ()
-  (first (xlib::installed-colormaps gem::*default-x-root*)))
+  (first (xlib::installed-colormaps *default-x-root*)))
 
 (defun run-make-color ()
   (xlib:make-color :red 1 :green 1 :blue 1))
@@ -22,4 +44,308 @@
 (defun alocate-color ()
   ;; get the pixel (device dependant 32 bit value) of a color (device
   ;; independant triplet of reals).
-  (xlib:alloc-color the-colormap run-make-color))
+  ;;(xlib:alloc-color the-colormap (run-make-color))
+  )
+
+
+
+(defstruct (menu)
+  "A simple menu of text strings."
+  (title "Choose an item:")
+  ;; E.g., '((item-window item-string))
+  item-alist
+  window
+  gcontext
+  width
+  title-width
+  item-width
+  item-height
+  (geometry-changed-p t))
+
+
+(defun create-menu (parent-window text-color background-color text-font)
+  (make-menu
+   ;; Create menu graphics context
+   :gcontext (create-gcontext :drawable
+			      parent-window
+			      :foreground text-color
+			      :background background-color
+			      :font
+			      text-font)
+   ;; Create menu window
+   :window (xlib:create-window
+	    :parent parent-window
+	    :class :input-output
+	    ;; temporary value
+	    :x 0
+	    ;; temporary value
+	    :y 0
+	    ;; temporary value
+	    :width 16
+	    ;; temporary value
+	    :height 16
+	    :border-width 2
+	    :border text-color
+	    :background background-color
+	    :save-under :on
+	    ;; override window mgr when positioning
+	    :override-redirect :on
+	    :event-mask
+	    (MAKE-EVENT-MASK :leave-window :exposure))))
+
+
+(defun menu-set-item-list (menu &rest item-strings)
+  ;; Assume the new items will change the menu’s width and height
+  (setf (menu-geometry-changed-p menu) t)
+  ;; Destroy any existing item windows
+  (dolist (item (menu-item-alist menu))
+    (destroy-window (first item)))
+  ;; Add (item-window item-string) elements to item-alist
+  (setf (menu-item-alist menu)
+	(let (alist)
+	  (dolist (item item-strings (nreverse alist))
+	    (push (list (xlib:create-window
+			 :parent (menu-window menu)
+			 :x 0
+			 :y 0
+			 :width 16
+			 :height 16
+			 :background (gcontext-background (menu-gcontext menu))
+			 :event-mask (make-event-mask :enter-window
+						      :leave-window
+						      :button-press
+						      :button-release))
+			item)
+		  alist)))))
+
+(defparameter *menu-item-margin* 4)
+
+(defun menu-highlight-item (menu position)
+  (let* ((box-margin  (round *menu-item-margin* 2))
+	 (left        (- (round (- (menu-width menu) (menu-item-width menu)) 2)
+			 box-margin))
+	 (top         (- (* (+ *menu-item-margin* (menu-item-height menu))
+			    (1+ position))
+			 box-margin))
+	 (width       (+ (menu-item-width menu) box-margin box-margin))
+	 (height      (+ (menu-item-height menu) box-margin box-margin)))
+    ;; Draw a box in menu window around the given item.
+    (xlib:draw-rectangle (menu-window menu)
+		    (menu-gcontext menu)
+		    left top
+		    width height)))
+
+(defun menu-recompute-geometry (menu)
+  (when (menu-geometry-changed-p menu)
+    (let* ((menu-font
+	    (gcontext-font (menu-gcontext menu)))
+	   (title-width (xlib:text-extents menu-font (menu-title menu)))
+	   (item-height (+ (font-ascent menu-font)
+			   (font-descent menu-font)
+			   *menu-item-margin*))
+	   (item-width 0)
+	   (items
+	    (menu-item-alist menu))
+	   menu-width)
+      ;; Find max item string width
+      (setf item-width
+	    (+ *menu-item-margin*
+	       (dolist (next-item items item-width)
+		 (setf item-width (max item-width
+				       (xlib:text-extents menu-font (second next-item)))))))
+      ;; Compute final menu width, taking margins into account
+      (setf menu-width (max title-width (+ item-width *menu-item-margin*)))
+      (let ((window
+	     (menu-window menu)))
+	;; Update width and height of menu window
+	(with-state (window)
+	  (setf (drawable-width
+		 window) menu-width
+		 (drawable-height window) (* (1+ (length items)) item-height)))
+	;; Update width, height, position of item windows
+	(let ((item-left
+	       (round (- menu-width item-width) 2))
+	      (next-item-top (- item-height (round *menu-item-margin* 2))))
+	  (dolist (next-item items)
+	    (let ((window (first next-item)))
+	      (with-state (window)
+		(setf (drawable-height window) item-height
+		      (drawable-width
+		       window) item-width
+		      (drawable-x
+		       window) item-left
+		      (drawable-y
+		       window) next-item-top)))
+	    (incf next-item-top item-height))))
+      ;; Map all item windows
+      (map-subwindows (menu-window menu))
+      ;; Save item geometry
+      (setf (menu-item-width menu)
+	    item-width
+	    (menu-item-height menu)
+	    item-height
+	    (menu-width menu)
+	    menu-width
+	    (menu-title-width menu)
+	    title-width
+	    (menu-geometry-changed-p menu) nil))))
+
+
+
+
+(defun menu-refresh (menu)
+  (let* ((gcontext
+	  (menu-gcontext menu))
+	 (baseline-y (FONT-ASCENT (GCONTEXT-FONT gcontext))))
+    ;; Show title centered in "reverse-video"
+    (let ((fg (gcontext-background gcontext))
+	  (bg (gcontext-foreground gcontext)))
+      (with-gcontext (gcontext :foreground fg :background bg)
+	(draw-image-glyphs
+	 (menu-window menu)
+	 gcontext
+	 (round (- (menu-width menu)
+		   (menu-title-width menu)) 2)
+	 baseline-y
+	 (menu-title menu))))
+    ;; Show each menu item (position is relative to item window)
+    (let ((box-margin (round *menu-item-margin* 2)))
+      (dolist (item (menu-item-alist menu))
+	(draw-image-glyphs
+	 (first item) gcontext
+	 box-margin
+	 (+ baseline-y box-margin)
+	 (second item))))))
+
+
+
+
+;; (let ((#:g595 (drawable-display mw))
+;;       (#:g596 nil))
+;;   (declare (type display #:g595))
+;;   (xlib::event-loop (#:g595 #:g594 nil t nil)
+;;     (xlib::event-dispatch (#:g595 #:g594 #:g596)
+;;       (:exposure (count) (progn (when (zerop count) (menu-refresh menu)) t))
+;;       (:button-release (event-window)
+;;        (progn (setf selected-item (second (assoc event-window items))) t))
+;;       (:enter-notify (window)
+;;        (progn (menu-highlight-item menu (find window items :key #'first)) t))
+;;       (:leave-notify (window kind)
+;;        (progn
+;;         (if (eql mw window)
+;;             (setf selected-item (when (eq kind :ancestor) :none))
+;;             (menu-unhighlight-item menu (find window items :key #'first)))
+;;         t))
+;;       (otherwise nil (progn t)))))
+
+(defun menu-present (menu x y)
+  ;; Make sure menu geometry is up-to-date
+  (menu-recompute-geometry menu)
+  ;; Try to center first item at the given location, but
+  ;; make sure menu is completely visible in its parent
+  (let ((menu-window (menu-window menu)))
+    (multiple-value-bind (tree parent) (query-tree menu-window)
+      (declare (ignore tree))
+      (with-state (parent)
+	(let* ((parent-width  (drawable-width parent))
+	       (parent-height (drawable-height parent))
+	       (menu-height   (+ *menu-item-margin*
+				 (* (1+ (length (menu-item-alist menu)))
+				    (+ (menu-item-height menu)  *menu-item-margin*))))
+	       (menu-x        (max 0 (min (- parent-width (menu-width menu))
+					  (- x (round (menu-width menu) 2)))))
+	       (menu-y        (max 0 (min (- parent-height menu-height)
+					  (- y (round (menu-item-height menu) 2/3)
+					     *menu-item-margin*)))))
+	  (with-state (menu-window)
+	    (setf (drawable-x menu-window) menu-x
+		  (drawable-y menu-window) menu-y)))))
+    ;; Make menu visible
+    (map-window menu-window)))
+
+(defun menu-choose (menu x y)
+  ;; Display the menu so that first item is at x,y.
+  (menu-present menu x y)
+  (let ((items (menu-item-alist menu))
+	(mw (menu-window menu))
+	selected-item)
+    ;; Event processing loop
+    (do ()
+	(selected-item)
+      (event-case ((drawable-display mw) :force-output-p t)
+	(:exposure
+	 (count)
+	 ;; Discard all but final :exposure then display the menu
+	 (when (zerop count) (menu-refresh menu))
+	 t)
+	(:button-release
+	 (event-window)
+	 ;;Select an item
+	 (setf selected-item (second (assoc event-window items)))
+	 t)
+	(:enter-notify
+	 (window)
+	 ;;Highlight an item
+	 (menu-highlight-item menu (find window items :key #'first))
+	 t)
+	(:leave-notify
+	 (window kind)
+	 (if (eql mw window)
+	     ;; Quit if pointer moved out of main menu window
+	     (setf selected-item
+		   (when (eq kind :ancestor)
+		     :none))
+	     ;; Otherwise, unhighlight the item window left
+	     (menu-unhighlight-item menu (find window items :key #'first)))
+	 t)
+	(otherwise
+	 ()
+	 ;;Ignore and discard any other event
+	 t)))
+    ;; Erase the menu
+    (unmap-window mw)
+    ;; Return selected item string, if any
+    (unless (eq selected-item :none)
+      selected-item)))
+
+(defun just-say-lisp (&optional host font-name)
+  (let* ((display
+	  (if host
+	      (open-display host)
+	      (xlib::open-default-display)))
+	 (screen
+	  (first (display-roots display)))
+	 (fg-color (screen-black-pixel screen))
+	 (bg-color (screen-white-pixel screen))
+	 ;; font-name used to have a default of "fg-16" But,
+	 ;; apperently, this is no longer commonly included in a basic
+	 ;; X11 installation. At least it was missing from Ubuntu 19.10.
+	 (nice-font (if font-name
+			(open-font display font-name)
+			(car (xlib:list-fonts
+			 (xlib::open-default-display)
+			 "*-adobe-times-medium-*34-240-*-170*-iso8859-1"))))
+	 ;; Create a menu as a child of the root window.
+	 (a-menu
+	  (create-menu (screen-root screen)
+		       fg-color bg-color nice-font)))
+    (setf (menu-title a-menu) "please pick your favorite language:")
+    (menu-set-item-list a-menu "fortran" "apl" "forth" "lisp")
+    ;; Bedevil the user until he picks a nice programming language
+    ;; (unwind-protect
+    ;; 	 (loop
+    ;; 	    ;; Determine the current root window position of the pointer
+    ;; 	    (multiple-value-bind (x y)
+    ;; 		(query-pointer (screen-root screen))
+    	      (let ((choice (menu-choose a-menu 50 50)))
+    		;; (when (string-equal "lisp" choice)
+    		;;   (return))
+		)
+    ;;   (close-display display))
+    ))
+
+(defun menu-unhighlight-item (menu position)
+  ;; Draw a box in the menu background color
+  (let ((gcontext (menu-gcontext menu)))
+    (with-gcontext (gcontext :foreground (gcontext-background gcontext))
+      (menu-highlight-item menu position))))

--- a/src/gem/gem-lab/insiders-guide-to-clx.org
+++ b/src/gem/gem-lab/insiders-guide-to-clx.org
@@ -1,0 +1,30 @@
+
+* Debugging
+
+  - X11 Misc
+    https://www.x.org/releases/individual/app/
+    https://www.x.org/wiki/guide/debugging/
+    https://gitlab.freedesktop.org/xorg/app/xscope
+    https://gitlab.freedesktop.org/xorg
+    
+  - Misc for building
+
+    sudo apt install xserver-xephyr-hwe-18.04
+    sudo apt-get install x11-utils
+    sudo apt-get build-dep x11-utils
+    
+
+  - Xephyr
+    Xephyr -ac -screen 1280x1024 -br -reset -terminate 2> /dev/null :1 &
+    https://www.x.org/archive/X11R7.5/doc/man/man1/Xephyr.1.html
+    apt-get update -y
+    sudo apt-get install -y xserver-xephyr
+
+  - xscope
+    find:
+    http://jklp.org/public/profession/papers/xscope/paper.htm
+    https://www.x.org/releases/X11R7.6/doc/man/man1/xscope.1.xhtml
+    
+    
+
+    

--- a/src/inter/i-windows.lisp
+++ b/src/inter/i-windows.lisp
@@ -15,6 +15,10 @@
 ;; Hitting the key *garnet-break-key* will cause an exit from the
 ;; main-event-loop and exit from replaying a transcript.
 
+(defvar *launch-process-p* nil)
+
+
+
 ;;  Functions to deal with transcripts
 
 (defparameter *trans-from-file* NIL) ; file to read from
@@ -610,23 +614,39 @@
 	(bordeaux-threads:current-thread))
   (gem:event-handler root-window NIL))
 
+;;; launch-process-p used to be defined for non-CMUCL
+;;; lisps. Unfortunately this feature is badly broken from a thread
+;;; safty persected and shouldn't be used
+(when *launch-process-p*
+  (opal:launch-main-event-loop-process))
 
-(opal:launch-main-event-loop-process)
-
+;; All of Garnett needs just one main event loop, which blocks until
+;; cancelled or no windows are visible (if exit-when-no-window-visible
+;; has been enabled)
 (defun main-event-loop (&key (exit-when-no-window-visible :on))
-  "Event handler for the interactor windows"
+  "Event handler for the interactor windows. If
+   :exit-when-no-window-visible is set to :on we block until no
+   windows are visable, otherwise we block until a cancel key it sent"
+  ;; Note, the only time *main-event-loop-process* is non-nil is if
+  ;; multi-threading is enabled. Since multi-threading is badly
+  ;; broken, that should be never. Multi-threading code is currently
+  ;; being kept in place to fascilitate better insight into the
+  ;; orriginal architectural intent. But fixing it will most likely
+  ;; require a vast overhall.
   (unless opal::*main-event-loop-process*
     (if (and (eq exit-when-no-window-visible :on)
 	     (not (opal::any-top-level-window-visible)))
 	(format t "Cannot call main-event-loop when no window is visible~%")
-	;; else do real work
+	;; else do real work,
 	(unless opal::*inside-main-event-loop*
 	  (let ((root-window (g-value gem:device-info :current-root)))
 	    (if (eq exit-when-no-window-visible :on)
 		(setq opal::*inside-main-event-loop* t)
 		(setq opal::*inside-main-event-loop* :dont-care))
 ;;	    (opal::m-e-l-new)		; Defined in opal/process.lisp
-	    (opal::m-e-l)		; Defined in opal/process.lisp
+	    ;; Defined in opal/process.lisp
+	    ;; (opal::m-e-l)
+	    (opal::process-m-e-l)
 	    (setq opal::*inside-main-event-loop* NIL)
 	    (gem:discard-pending-events root-window 5))))))
 


### PR DESCRIPTION
CLX is fundamentally at odds with the way multi-threading is implemented in Garnett, switching it off by default with healthy warning that the feature is broken.