### PR TITLE
Fix infinite loop during loading on systems missing specific xfonts

### DIFF
--- a/clx-compatability.lisp
+++ b/clx-compatability.lisp
@@ -2,16 +2,20 @@
 
 (in-package :xlib)
 
-(defun pixmap-p (object)
-  (typep object 'pixmap))
+(unless (fboundp 'pixmap-p)
+  (defun pixmap-p (object)
+    (typep object 'pixmap)))
 
-(defun image-z-p (object)
-  (typep object 'image-z))
+(unless (fboundp 'image-z-p)
+  (defun image-z-p (object)
+    (typep object 'image-z)))
 
 (export 'xlib::image-z-p :xlib)
 
-(defun pixmap-plist (pixmap)
-  (xlib:drawable-plist pixmap))
+(unless (fboundp 'pixmap-plist)
+  (defun pixmap-plist (pixmap)
+    (xlib:drawable-plist pixmap)))
 
-(defun (setf pixmap-plist) (value window)
-  (setf (drawable-plist window) value))
+(unless (fboundp '(setf pixmap-plist))
+  (defun (setf pixmap-plist) (value window)
+    (setf (drawable-plist window) value)))

--- a/src/c32/c32-lapidary.lisp
+++ b/src/c32/c32-lapidary.lisp
@@ -18,7 +18,7 @@
 (defun c32-ok-function ()
   ;; allow no windows to be selected by the obj-find interactor
   (s-value (g-value c32::ask-object :obj-find) :window nil)
-  (setf lapidary-p nil)
+  (setf *lapidary-p* nil)
   (dolist (win *All-windows*)
     (if (schema-p win)
       (s-value win :visible nil)))
@@ -29,8 +29,8 @@
 
 (defun lapidary-QuitFunc (gadget sel)
   (declare (ignore gadget sel))
-  (declare (special lapidary-p))
-  (if lapidary-p
+  (declare (special *lapidary-p*))
+  (if *lapidary-p*
       (c32-ok-function)
       (progn
 	(do-stop)
@@ -158,8 +158,8 @@
 		       "should be a parameter, please edit the "
 		       "formula and use either 'Insert Ref From Spread...' "
 		       "or 'Insert Ref from Mouse' to insert the reference. "
-		       "Do you want to edit the formula?"
-		  expr))
+		       "Do you want to edit the formula?")
+		  expr)
 	 ;; else the expr is not a view-object, so return nil
 	 nil)))))
 

--- a/src/c32/c32formula.lisp
+++ b/src/c32/c32formula.lisp
@@ -210,7 +210,7 @@
 
 
 (defun Do-Form-Cancel (gadget item)
-  (if lapidary-p
+  (if *lapidary-p*
     ;; Specialized version.
     (lapidary-Do-Form-Cancel gadget item)
     ;; Stand-alone version.
@@ -222,7 +222,7 @@
 
 
 (defun Do-Form-Ok (gadget item)
-  (if lapidary-p
+  (if *lapidary-p*
     ;; Specialized version.
     (lapidary-Do-Form-Ok gadget item)
     ;; Stand-alone version.

--- a/src/gem/x.lisp
+++ b/src/gem/x.lisp
@@ -1696,13 +1696,10 @@ this display."
               ;; The default font cannot be loaded, now just attempt loading ANY font
               (t
                (format t "WARNING: Default font could not be loaded~~%")
-               (format t "   ****   Resorting to loading any available xserver fonts")
-               (let ((xfont (xlib:open-font
-                             display
-                             (first (xlib:list-font-names display "*")))))
-		         (s-value font-from-file :display-xfont-plist
-			              (cons display (cons xfont dx-plist)))
-		         xfont))))))))
+               (format t "   ****   Resorting to loading any available xserver font")
+               (xlib:open-font
+                display
+                (first (xlib:list-font-names display "*"))))))))))
 
 
 ;;; Sets the Cut buffer for X.  Note that this does NOT do a select, and

--- a/src/gem/x.lisp
+++ b/src/gem/x.lisp
@@ -642,69 +642,70 @@ this display."
                         min-width min-height max-width max-height
                         user-specified-position-p user-specified-size-p
                         override-redirect)
+  (declare (ignore visible))
   (when *x11-server-available*
     (let* ((display-info (g-value parent-window :display-info))
-	   (drawable (xlib:create-window
-		      :bit-gravity :north-west
-		      :backing-store :always
-		      :parent (g-value parent-window :drawable)
-		      :x x
-		      :y y
-		      :width width
-		      :height height
-		      :background background
-		      :border-width border-width
-		      :border (xlib:screen-black-pixel (display-info-screen
-							display-info))
-		      :override-redirect override-redirect
-		      :event-mask *exposure-event-mask*
-		      :save-under save-under
-		      :class :input-output)))
+	       (drawable (xlib:create-window
+		              :bit-gravity :north-west
+		              :backing-store :always
+		              :parent (g-value parent-window :drawable)
+		              :x x
+		              :y y
+		              :width width
+		              :height height
+		              :background background
+		              :border-width border-width
+		              :border (xlib:screen-black-pixel (display-info-screen
+							                            display-info))
+		              :override-redirect override-redirect
+		              :event-mask *exposure-event-mask*
+		              :save-under save-under
+		              :class :input-output)))
       (setf (xlib:wm-hints drawable)
-	    (xlib:make-wm-hints))
+	        (xlib:make-wm-hints))
       (setf (xlib:wm-hints-input (xlib:wm-hints drawable)) :on)
       (setf (xlib:wm-hints-initial-state (xlib:wm-hints drawable)) :normal)
       (setf (xlib:wm-normal-hints drawable)
-	    (xlib:make-wm-size-hints
-	     :width-inc 1
-	     :height-inc 1
-	     ;; wm-size-hints-y has been obsolete for several
-	     ;; decades. Apperently, at one time it was used instead
-	     ;; of ConfigureWindow?
-	     ;; :x x
-	     ;; :y y
-	     :min-width min-width
-	     :min-height min-height
-	     :max-width max-width
-	     :max-height max-height
-	     :user-specified-position-p user-specified-position-p
-	     ;; :user-specified-size-p user-specified-size-p
-	     ))
+	        (xlib:make-wm-size-hints
+	         :width-inc 1
+	         :height-inc 1
+	         ;; wm-size-hints-y has been obsolete for several
+	         ;; decades. Apperently, at one time it was used instead
+	         ;; of ConfigureWindow?
+	         ;; :x x
+	         ;; :y y
+	         :min-width min-width
+	         :min-height min-height
+	         :max-width max-width
+	         :max-height max-height
+	         :user-specified-position-p user-specified-position-p
+	         ;; :user-specified-size-p user-specified-size-p
+	         ))
       (setf (xlib:wm-size-hints-user-specified-size-p (xlib:wm-normal-hints drawable))
-	    user-specified-size-p)
+	        user-specified-size-p)
       (xlib:set-wm-properties drawable
-			      ;; :client-machine
-			      ;; (machine-instance)
-			      :resource-name "Opal"
-			      :resource-class :opal
-			      :name title
-			      :icon-name icon-name)
-    ;;; The following allows you to destroy windows by hand using the
-    ;;; window manager.  Unfortunately, this does not work in lispworks, but
-    ;;; causes an error with mysterious message "#\U is not of type integer".
-    ;;;
-    ;;; The same error appeared in clisp before the addition of
-    ;;; :TRANSFORM #'xlib:char->card8. I guess it is related to missing error
-    ;;; error checking in other implementations than clisp and lispworks.
-    ;;; B. Haible 20.9.1993
+			                  ;; :client-machine
+			                  ;; (machine-instance)
+			                  :resource-name "Opal"
+			                  :resource-class :opal
+			                  :name title
+			                  :icon-name icon-name)
+;;; The following allows you to destroy windows by hand using the
+;;; window manager.  Unfortunately, this does not work in lispworks, but
+;;; causes an error with mysterious message "#\U is not of type integer".
+;;;
+;;; The same error appeared in clisp before the addition of
+;;; :TRANSFORM #'xlib:char->card8. I guess it is related to missing error
+;;; error checking in other implementations than clisp and lispworks.
+;;; B. Haible 20.9.1993
       (xlib:change-property drawable
-			    :WM_CLIENT_MACHINE (short-site-name)
-			    :STRING 8)
+			                :WM_CLIENT_MACHINE (short-site-name)
+			                :STRING 8)
       (xlib:change-property drawable :WM_PROTOCOLS
-			    (list (xlib:intern-atom
-				   (display-info-display display-info)
-				   "WM_DELETE_WINDOW"))
-			    :ATOM 32)
+			                (list (xlib:intern-atom
+				                   (display-info-display display-info)
+				                   "WM_DELETE_WINDOW"))
+			                :ATOM 32)
       drawable)))
 
 (defun x-delete-font (root-window font)
@@ -755,7 +756,7 @@ this display."
                                         ; event-case to terminate), which causes
                                         ; loop to terminate
 	 (return)))
-    #+ALLEGRO
+    #+allegro
     (block throw-away
       (xlib:event-case (*default-x-display*
                         :discard-p t :timeout 0)
@@ -1225,15 +1226,15 @@ this display."
 	       :initial-value t)))
 
 (defun lookup-composite-event (event-type-list)
-  (and (> (length event) 1)
+  (and (> (length *composite-events*) 1)
        (dolist (composite-event *composite-events* )
-	 (if (and (= (length event-type-list) (length composite-event))
-		  (reduce (lambda (result item) (and result (eq (car item) (cdr item))))
-			  (mapcar #'cons
-				  event-type-list
-				  composite-event)
-			  :initial-value t))
-	     (return t)))))
+	     (if (and (= (length event-type-list) (length composite-event))
+		          (reduce (lambda (result item) (and result (eq (car item) (cdr item))))
+			              (mapcar #'cons
+				                  event-type-list
+				                  composite-event)
+			              :initial-value t))
+	         (return t)))))
 
 (defun get-event-type (event)
   (car (reverse event)))
@@ -1256,26 +1257,27 @@ this display."
   (setf *my-root-window* root-window)
   (setf  *my-ignore-keys* ignore-keys)
   (apply 'process-x-event
-	 (let* ((building-composit-event nil)
-		(valid-event nil)
-		(composite-event nil))
-	   (declare (ignore building-composit-event))
-	   (declare (ignore valid-event))
-	   (do* ((event (fetch-next-event root-window ignore-keys)
-			(fetch-next-event root-window ignore-keys))
-		 (composite-event (if event
-				      (push (get-event-type event) composite-event)
-				      composite-event)
-				  (if event
-				      (push (get-event-type event) composite-event)
-				      composite-event)))
-		((or (timeout-p composit-event)
-		     (not (any-more-p composite-event)))
-		 (if (valid-event-p composite-event)
-		     (create-garnet-event composite-event)
-		     nil))
-	     (format t "event: ~s!%" event)
-	     (push event composite-event)))))
+	     (let* ((building-composit-event nil)
+		        (valid-event nil)
+		        (composite-event nil))
+	       (declare (ignore building-composit-event))
+	       (declare (ignore valid-event))
+	       (do* ((event (fetch-next-event root-window ignore-keys)
+			            (fetch-next-event root-window ignore-keys))
+		         (composite-event (if event
+				                      (push (get-event-type event) composite-event)
+				                      composite-event)
+				                  (if event
+				                      (push (get-event-type event) composite-event)
+				                      composite-event)))
+		        ((or (timeout-p composite-event)
+		             (not (any-more-p composite-event)))
+		         (if (valid-event-p composite-event)
+                     ;; this function seems to be undefined
+  		             (create-garnet-event composite-event)
+		             nil))
+	         (format t "event: ~s!%" event)
+	         (push event composite-event)))))
 
 (defun fetch-next-event (root-window ignore-keys)
   (let* ((display (the-display root-window))
@@ -2301,13 +2303,14 @@ integer.  We want to specify nice keywords instead of those silly
     (:LEFT
      (let* ((drawable (g-value window :drawable))
             (hints (xlib:wm-normal-hints drawable)))
+       (declare (ignore hints))
        (setf (xlib:drawable-x drawable) value
-	     ;; wm-size-hints-y has been obsolete for several
-	     ;; decades. Apperently, at one time it was used instead
-	     ;; of ConfigureWindow?
+	         ;; wm-size-hints-y has been obsolete for several
+	         ;; decades. Apperently, at one time it was used instead
+	         ;; of ConfigureWindow?
              ;; (xlib:wm-size-hints-x hints) value
              ;; (xlib:wm-normal-hints drawable) hints
-	     ))
+	         ))
      nil)
     (:PARENT
      (let ((left (g-value window :left))
@@ -2349,13 +2352,14 @@ integer.  We want to specify nice keywords instead of those silly
     (:TOP
      (let* ((drawable (g-value window :drawable))
             (hints (xlib:wm-normal-hints drawable)))
+       (declare (ignore hints))
        (setf (xlib:drawable-y drawable) value
-	     ;; wm-size-hints-y has been obsolete for several
-	     ;; decades. Apperently, at one time it was used instead
-	     ;; of ConfigureWindow?
+	         ;; wm-size-hints-y has been obsolete for several
+	         ;; decades. Apperently, at one time it was used instead
+	         ;; of ConfigureWindow?
              ;; (xlib:wm-size-hints-y hints) value
              ;; (xlib:wm-normal-hints drawable) hints
-	     ))
+	         ))
      nil)
     (:VISIBLE
      (let* ((drawable (g-value window :drawable))

--- a/src/gem/x.lisp
+++ b/src/gem/x.lisp
@@ -1697,7 +1697,7 @@ this display."
 
               ;; The default font cannot be loaded, now just attempt loading ANY font
               (t
-               (format t "WARNING: Default font could not be loaded~~%")
+               (format t "WARNING: Default font could not be loaded~%")
                (format t "   ****   Resorting to loading any available xserver font")
                (xlib:open-font
                 display

--- a/src/gem/x.lisp
+++ b/src/gem/x.lisp
@@ -1661,33 +1661,48 @@ this display."
         (display (the-display root-window)))
     (when *x11-server-available*
       (or (getf dx-plist display)
-	  (let ((font-path (fix-font-path
-			    (g-value font-from-file :font-path)))
-		(font-name (g-value font-from-file :font-name)))
-	    (when font-path
-	      (let ((xfont-path (mapcar #'remove-null-char
-					(xlib:font-path display))))
-              ;;; Add the font-path to the font-path, if necessary
-		(unless (member font-path xfont-path :test #'string=)
-		  (setf (xlib:font-path display)
-			(cons font-path xfont-path))
-                ;;; Now make sure it's there!
-		  (unless (member font-path (xlib:font-path display)
-				  :test #'string=)
-		    (format t "WARNING: X did not add ~A to font-path!!~%"
-			    font-path)))))
-          ;;; Open the font only if it's on the font-path
-	    (if (xlib:list-font-names display font-name)
-		(let ((xfont (xlib:open-font display font-name)))
-		  (s-value font-from-file :display-xfont-plist
-			   (cons display (cons xfont dx-plist)))
-		  xfont)
-		(progn
-		  (format t "WARNING: Font '~A' not on font path!~%"
-			  font-name)
-		  (format t "  ****   Resorting to Default Font!~%")
-		  (x-font-to-internal root-window default-font-from-file))))))))
+	      (let ((font-path (fix-font-path
+			                (g-value font-from-file :font-path)))
+		        (font-name (g-value font-from-file :font-name)))
+	        (when font-path
+	          (let ((xfont-path (mapcar #'remove-null-char
+					                    (xlib:font-path display))))
+                ;; Add the font-path to the font-path, if necessary
+		        (unless (member font-path xfont-path :test #'string=)
+		          (setf (xlib:font-path display)
+			            (cons font-path xfont-path))
+                  ;; Now make sure it's there!
+		          (unless (member font-path (xlib:font-path display)
+				                  :test #'string=)
+		            (format t "WARNING: X did not add ~A to font-path!!~%"
+			                font-path)))))
 
+	        (cond
+              
+              ;; Open the font only if it's on the font-path
+              ((xlib:list-font-names display font-name)
+		       (let ((xfont (xlib:open-font display font-name)))
+		         (s-value font-from-file :display-xfont-plist
+			              (cons display (cons xfont dx-plist)))
+		         xfont))
+
+              ;; Attempt loading default font if that has not been attempted
+              ((not (eq default-font-from-file font-from-file))
+		       (format t "WARNING: Font '~A' not on font path!~%"
+			           font-name)
+		       (format t "  ****   Resorting to Default Font!~%")
+		       (x-font-to-internal root-window default-font-from-file))
+
+              ;; The default font cannot be loaded, now just attempt loading ANY font
+              (t
+               (format t "WARNING: Default font could not be loaded~~%")
+               (format t "   ****   Resorting to loading any available xserver fonts")
+               (let ((xfont (xlib:open-font
+                             display
+                             (first (xlib:list-font-names display "*")))))
+		         (s-value font-from-file :display-xfont-plist
+			              (cons display (cons xfont dx-plist)))
+		         xfont))))))))
 
 
 ;;; Sets the Cut buffer for X.  Note that this does NOT do a select, and

--- a/src/kr/kr-macros.lisp
+++ b/src/kr/kr-macros.lisp
@@ -645,17 +645,17 @@ You can also provide a documentation string as the last parameter, as in:
      (def-kr-type my-named-type () '(or keyword null) \"Sample doc string\")"
 
   (cond ((listp typename-or-type)
-	   (unless (eq (car typename-or-type) 'QUOTE)
-	     (error "Illegal typename to def-kr-type: ~S" typename-or-type))
-	   (unless (and (null args) (null body) (null type-doc))
-	     (error "Illegal specification: (DEF-KR-TYPE ~S ~S ~S ~S)"
-			typename-or-type args body type-doc))
-	   (setq body typename-or-type)
-	   (setq typename-or-type NIL))
+	     (unless (eq (car typename-or-type) 'QUOTE)
+	       (error "Illegal typename to def-kr-type: ~S" typename-or-type))
+	     (unless (and (null args) (null body) (null type-doc))
+	       (error "Illegal specification: (DEF-KR-TYPE ~S ~S ~S ~S)"
+			      typename-or-type args body type-doc))
+	     (setq body typename-or-type)
+	     (setq typename-or-type NIL))
         (args
-	   (error "DEF-KR-TYPE only works with NULL args, not ~S~%" args))
+	     (error "DEF-KR-TYPE only works with NULL args, not ~S~%" args))
         (T
-	   (setq typename-or-type (symbol-name typename-or-type))))
+	     (setq typename-or-type (symbol-name typename-or-type))))
   (setq body (eval body))
   `(add-new-type ,typename-or-type ',body ,(type-to-fn body) ,type-doc))
 

--- a/src/kr/kr.lisp
+++ b/src/kr/kr.lisp
@@ -525,14 +525,14 @@ an inherited formula."
   "Given simple type ('NULL, 'KEYWORD, etc...), returns the name of
 the lisp predicate to test this ('NULL, 'KEYWORDP, etc....)"
   (let ((p-name (concatenate 'string (symbol-name simple-type) "P"))
-	(-p-name (concatenate 'string (symbol-name simple-type) "-P")))
+	    (-p-name (concatenate 'string (symbol-name simple-type) "-P")))
     (cond ((memberq simple-type '(NULL ATOM)) simple-type)
-	  (T (or (find-symbol p-name 'common-lisp)
-		 (find-symbol -p-name 'common-lisp)
-		 (find-symbol p-name)
-		 (find-symbol -p-name)
-		 (error "Could not find predicate for simple-type ~S~%"
-			simple-type))))))
+	      (T (or (find-symbol p-name 'common-lisp)
+		         (find-symbol -p-name 'common-lisp)
+		         (find-symbol p-name)
+		         (find-symbol -p-name)
+		         (error "Could not find predicate for simple-type ~S~%"
+			            simple-type))))))
 
 (defun make-lambda-body (complex-type)
   (with-types-table-lock-held (types-table)
@@ -577,17 +577,17 @@ the lisp predicate to test this ('NULL, 'KEYWORDP, etc....)"
   (with-types-table-lock-held (types-table)
     (let (code)
       (cond ((consp type)			; complex type
-	     (if (eq (car type) 'SATISFIES)
-		 (let ((fn-name (second type)))
-		   `',fn-name) ;; koz
-		 `(function (lambda (value)
-		    (declare #.*special-kr-optimization*)
-		    ,(make-lambda-body type)))))
-	    ((setq code (gethash (symbol-name type) types-table))
-	     ;; is this a def-kr-type?
-	     (code-to-type-fn code))
-	    (T
-	     `',(find-lisp-predicate type))))))
+	         (if (eq (car type) 'SATISFIES)
+		         (let ((fn-name (second type)))
+		           `',fn-name) ;; koz
+		         `(function (lambda (value)
+		            (declare #.*special-kr-optimization*)
+		            ,(make-lambda-body type)))))
+	        ((setq code (gethash (symbol-name type) types-table))
+	         ;; is this a def-kr-type?
+	         (code-to-type-fn code))
+	        (T
+             `',(find-lisp-predicate type))))))
 
 (declaim (inline copy-extend-array))
 (defun copy-extend-array (oldarray oldlen newlen)
@@ -619,35 +619,35 @@ Always returns the CODE of the resulting type (whether new or not)"
   (with-types-table-lock-held (types-table)
     (let ((code (gethash (or typename type-body) types-table)))
       (if code
-	  ;; redefining same name
-	  (if (equal (code-to-type code) type-body)
-	      ;; redefining same name, same type
+	      ;; redefining same name
+	      (if (equal (code-to-type code) type-body)
+	          ;; redefining same name, same type
+	          (progn
+		        (format t "Ignoring redundant def-kr-type of ~S to ~S~%"
+			            typename type-body)
+		        (return-from add-new-type code))
+	          ;; redefining same name, new type --> replace it!
+	          (format t "def-kr-type redefining ~S from ~S to ~S~%"
+		              typename (code-to-type code) type-body))
+	      ;; defining a new name, establish new code
 	      (progn
-		(format t "Ignoring redundant def-kr-type of ~S to ~S~%"
-			typename type-body)
-		(return-from add-new-type code))
-	      ;; redefining same name, new type --> replace it!
-	      (format t "def-kr-type redefining ~S from ~S to ~S~%"
-		      typename (code-to-type code) type-body))
-	  ;; defining a new name, establish new code
-	  (progn
-	    (setq code (or (gethash type-body types-table)
-			   (get-next-type-code)))
-	    (setf (gethash typename types-table) code)))
+	        (setq code (or (gethash type-body types-table)
+			               (get-next-type-code)))
+	        (setf (gethash typename types-table) code)))
       (unless (gethash type-body types-table)
-	(setf (gethash type-body types-table) code))
+	    (setf (gethash type-body types-table) code))
       (setf (svref types-array code)
-	    (if typename
-		(if (stringp typename)
-		    (intern typename (find-package "KR"))
-		    typename)
-		type-body))
+	        (if typename
+		        (if (stringp typename)
+		            (intern typename (find-package "KR"))
+		            typename)
+		        type-body))
       (setf (svref type-docs-array code) (or type-doc NIL))
       (setf (svref type-fns-array  code)
-	    (if (and (symbolp type-fn) ;; koz
-		     (fboundp type-fn))
-		(symbol-function type-fn)
-		type-fn))
+	        (if (and (symbolp type-fn) ;; koz
+		             (fboundp type-fn))
+		        (symbol-function type-fn)
+		        type-fn))
       code)))
 
 (defun kr-type-error (type)
@@ -2672,13 +2672,13 @@ Example:
  (OR NULL (IS-A-P OPAL:BITMAP))
 "
   (let* ((name (if (symbolp type-descriptor) (symbol-name type-descriptor)))
-	 (code (gethash name kr::types-table)))
+	 (code (gethash name *types-table*)))
     (when name
       (maphash #'(lambda (key value)
 		   (when (and (eq value code)
 			    (not (stringp key)))
 		       (return-from get-type-definition key)))
-	       kr::types-table))))
+	       *types-table*))))
 
 
 

--- a/src/opal/types.lisp
+++ b/src/opal/types.lisp
@@ -149,8 +149,13 @@
 
 (defun fixnump (object) (typep object 'fixnum))
 
+#+sbcl
 (def-kr-type fixnum ()
   '(satisfies sb-int:fixnump)
+  "Potential efficiency hack.")
+#-sbcl
+(def-kr-type fixnum ()
+  'fixnum
   "Potential efficiency hack.")
 
 ;;;; Unnamed types used in Opal, Interactors, etc.

--- a/src/opal/utils.lisp
+++ b/src/opal/utils.lisp
@@ -98,35 +98,42 @@
 
 
 (defun make-image (filename &rest args)
-    (error "Don't know how to automatically save an image for this
+  (error "Don't know how to automatically save an image for this
             lisp.  Please consult your lisp's user manual for
             instructions.~%")
 
-    (multiple-value-bind (quit gc verbose libfile flush-source-info? extra-args)
-	(extract-image-args args)
-  ;; When the image is restarted, we want *readtable* to be restored
-  ;; to its current value, instead of being reinitialized to the
-  ;; default.  This will keep the #k<> and #f() reader macros active
-  ;; in the saved image.
+  (multiple-value-bind (quit gc verbose libfile flush-source-info? extra-args)
+	  (extract-image-args args)
+    ;; When the image is restarted, we want *readtable* to be restored
+    ;; to its current value, instead of being reinitialized to the
+    ;; default.  This will keep the #k<> and #f() reader macros active
+    ;; in the saved image.
     (when verbose (format t "Disconnecting Garnet..."))
     (opal:disconnect-garnet)
     (when verbose (format t "disconnected.~%"))
-  (setf garnet-image-date (time-to-string))
-  (when gc
-    (when verbose (format t "Garbage collecting..."))
-    (sb-ext:gc :full t)
-    (when verbose (format t "collected.~%")))
+    (setf garnet-image-date (time-to-string))
+    (when gc
+      (when verbose (format t "Garbage collecting..."))
+      #+sbcl
+      (sb-ext:gc :full t)
+      #-sbcl
+      (format t "Warning: don't know how to GC on this lisp~%")
+      (when verbose (format t "collected.~%")))
 
-  (setf garnet-user::*herald-items* nil)
-  (setf (getf garnet-user::*herald-items* :garnet)
-	`("    Garnet Version " ,common-lisp-user::garnet-version-number))
+    (setf garnet-user::*herald-items* nil)
+    (setf (getf garnet-user::*herald-items* :garnet)
+	      `("    Garnet Version " ,common-lisp-user::garnet-version-number))
 
-  (when verbose (format t "Saving image..."))
-  (setf sb-ext:*init-hooks*
-	(append sb-ext:*init-hooks* (list #'garnet-restart-function)))
-  (trivial-dump-core:dump-image filename)
-  (when verbose
-    (format t "saved.~%"))))
+    (when verbose (format t "Saving image..."))
+
+    #+sbcl
+    (setf sb-ext:*init-hooks*
+	      (append sb-ext:*init-hooks* (list #'garnet-restart-function)))
+    #-sbcl
+    (format t "Warning: unable to add restart function to init hooks~%")
+    (trivial-dump-core:dump-image filename)
+    (when verbose
+      (format t "saved.~%"))))
 
 (defun Get-Garnet-Bitmap (bitmapname)
   (opal:read-image (merge-pathnames bitmapname cl-user::Garnet-Bitmap-PathName)))

--- a/src/protected-eval/prompter.lisp
+++ b/src/protected-eval/prompter.lisp
@@ -150,8 +150,7 @@
 	(opal:update window)))
     (when waiting (inter:interaction-complete (list value but-value)))))
 
-(or (kr:def-kr-type Package () 'Package)
-    t)
+(kr:def-kr-type Package () 'Package)
 
 ;; note: if :parent-window is specified, then the parent window must
 ;; already have been opal:update'd when the instance of ERROR-GADGET


### PR DESCRIPTION
Closes #18 


Before I got an infinite loop when I attempted to compile this

```

WARNING: Font '*-*-courier-medium-r-*-*-*-180-*-*-*-*-iso8859-1' not on font path!
  ****   Resorting to Default Font!
WARNING: Font '*-*-courier-medium-r-*-*-*-180-*-*-*-*-iso8859-1' not on font path!
  ****   Resorting to Default Font!
WARNING: Font '*-*-courier-medium-r-*-*-*-180-*-*-*-*-iso8859-1' not on font path!
  ****   Resorting to Default Font!
WARNING: Font '*-*-courier-medium-r-*-*-*-180-*-*-*-*-iso8859-1' not on font path!
  ****   Resorting to Default Font!
WARNING: Font '*-*-courier-medium-r-*-*-*-180-*-*-*-*-iso8859-1' not on font path!
  ****   Resorting to Default Font!
  
  ```
  
  
  
 The error was caused by the x-font-to-internal function attempting to recursively call itself with some default args whenever font loading failed. However, in the case that loading the front from the default args failed, it would recursively call itself infinitely. I added a check for this case to stop the infinite loop.
 
 I also fixed some other minor bugs causing compilation errors
 
UPDATE: I have also fixed other compilation errors prevent sbcl from loading garnet. I got it working on ecl by adding feature checks for sbcl specific calls